### PR TITLE
Kafka With Zookeper Containers Created

### DIFF
--- a/KAFKAME.md
+++ b/KAFKAME.md
@@ -1,0 +1,13 @@
+# create a new topic 
+docker exec -it <kafka_container_id> /bin/bash
+
+# exec into kafka conatiner to create a topics 
+kafka-topics --create --topic project1_logs --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+
+# exec into kafka conatiner to see list of topics created 
+kafka-topics --list --bootstrap-server localhost:9092
+
+# exec into kafka conatiner to see logs of topic
+docker exec <kafka-conatiner-id> kafka-console-consumer --topic <topic-name> --bootstrap-server localhost:9092 --from-beginning
+docker exec kafka kafka-console-consumer --bootstrap-server kafka:9092 --topic <topic-name> --from-beginning
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,36 +17,30 @@ services:
       - redis_data:/data
 
   zookeeper:
-    image: bitnami/zookeeper:latest
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
     ports:
       - "2181:2181"
-    environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-      - ZOO_MY_ID=1
-    volumes:
-      - zookeeper_data:/bitnami/zookeeper/data
-      - zookeeper_logs:/bitnami/zookeeper/logs
 
   kafka:
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
     ports:
       - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_LISTENERS: INSIDE://0.0.0.0:9092,OUTSIDE://kafka:9093
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9092,OUTSIDE://localhost:9093
-      KAFKA_LISTENER_NAME_PREFIXES: INSIDE,OUTSIDE
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      ALLOW_PLAINTEXT_LISTENER: "yes"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    entrypoint: ["/usr/bin/create_kafka_topic.sh"]
-    depends_on:
-      - zookeeper
+      # KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"  # Enable auto topic creation default
+    # Command to create a default topic when the container starts
+    # command: [bash, -c, "echo 'auto.create.topics.enable=true' >> /etc/kafka/server.properties && /etc/confluent/docker/run"]
 
   web:
     build: .


### PR DESCRIPTION
# Added kafka and zookeper Conatiners for logging

- updateed the docker-compose file which pull the public image of kafka and zookeeper
- This will create a zooperper container first and then create ka kafka container 
- The kafka container only connect to locally inside the docker-network using kafka:9092
- The Kafka container automatic create a new topic for the container 

# Added the README for kafka as KAFKAME.md 
- here you can get all the info about how to use the kafka conatiners. 
